### PR TITLE
feat: add ios ignore_security

### DIFF
--- a/ios/tobias.podspec
+++ b/ios/tobias.podspec
@@ -30,9 +30,15 @@ end
 
 Pod::UI.puts "using sdk with #{tobias_subspec}"
 
+ignore_security = ''
+if cfg['fluwx'] && cfg['tobias']['ios'] && cfg['tobias']['ios']['ignore_security'] == true
+    ignore_security = '-i'
+end
+Pod::UI.puts "ignore_security: #{ignore_security}"
+
 if cfg['tobias'] && cfg['tobias']['url_scheme']
     url_scheme = cfg['tobias']['url_scheme']
-    system("ruby #{current_dir}/tobias_setup.rb -u #{url_scheme} -p #{project_dir} -n Runner.xcodeproj")
+    system("ruby #{current_dir}/tobias_setup.rb #{ignore_security} -u #{url_scheme} -p #{project_dir} -n Runner.xcodeproj")
 else
     abort("required values:[url_scheme] are missing. Please add them in pubspec.yaml:\ntobias:\n  url_scheme: ${url scheme}\n")
 end

--- a/ios/tobias_setup.rb
+++ b/ios/tobias_setup.rb
@@ -24,6 +24,10 @@ OptionParser.new do |options|
         options_dict[:project_name] = name
     end
 
+    options.on("-i", "--ignoreSecurity", "Ignore modifying NSAppTransportSecurity") do |opts|
+        options_dict[:ignore_security] = true
+    end
+
     options.on("-u", "--urlScheme=URLSCHEME", String, "url scheme for AliPay") do |opts|
         options_dict[:url_scheme] = opts
     end
@@ -96,18 +100,20 @@ project.targets.each do |target|
                 end
                 File.write(infoplistFile, Plist::Emit.dump(result))
             end
-            security = result["NSAppTransportSecurity"]
-            if !security
-                security = {}
-                result["NSAppTransportSecurity"] = security
-            end
-            if security["NSAllowsArbitraryLoads"] != true
-                security["NSAllowsArbitraryLoads"] = true
-                File.write(infoplistFile, Plist::Emit.dump(result))
-            end
-            if security["NSAllowsArbitraryLoadsInWebContent"] != true
-                security["NSAllowsArbitraryLoadsInWebContent"] = true
-                File.write(infoplistFile, Plist::Emit.dump(result))
+            if !options_dict[:ignore_security]
+                security = result["NSAppTransportSecurity"]
+                if !security
+                    security = {}
+                    result["NSAppTransportSecurity"] = security
+                end
+                if security["NSAllowsArbitraryLoads"] != true
+                    security["NSAllowsArbitraryLoads"] = true
+                    File.write(infoplistFile, Plist::Emit.dump(result))
+                end
+                if security["NSAllowsArbitraryLoadsInWebContent"] != true
+                    security["NSAllowsArbitraryLoadsInWebContent"] = true
+                    File.write(infoplistFile, Plist::Emit.dump(result))
+                end
             end
         end
         sectionObject.build_configurations.each do |config|


### PR DESCRIPTION
每次运行插件会自动修改 iOS 的 info.plist 中

```
<key>NSAppTransportSecurity</key>
<dict>
<key>NSAllowsArbitraryLoads</key>
<true/>
<key>NSAllowsArbitraryLoadsInWebContent</key>
<true/>
</dict>
```

新增 `ignore_security` 禁用这个特性:

```
tobias:
  ios:
    ignore_security: true
```